### PR TITLE
Avoid crash when Fidesmo App is not installed

### DIFF
--- a/src/main/java/com/fidesmo/sec/transceivedemo/MainActivity.java
+++ b/src/main/java/com/fidesmo/sec/transceivedemo/MainActivity.java
@@ -3,16 +3,21 @@ package com.fidesmo.sec.transceivedemo;
 
 import android.app.Activity;
 import android.content.Intent;
+import android.content.pm.PackageManager;
 import android.os.Bundle;
 import android.util.Log;
 import android.view.View;
 import android.view.View.OnClickListener;
 import android.widget.Button;
+import android.widget.Toast;
 
 public class MainActivity extends Activity {
 
     // String for LogCat documentation
     private final static String TAG = "Fidesmo-Client-Example";
+
+    // Fidesmo App package
+    private final static String FIDESMO_APP = "com.fidesmo.sec.android";
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -25,13 +30,20 @@ public class MainActivity extends Activity {
         Button serviceDeliveryButton = (Button) findViewById(R.id.service_delivery_button);
         Button transceiveToDeviceFidelityButton = (Button) findViewById(R.id.transceive_button);
 
+        // Detect if the Fidesmo App is installed
+        final boolean fidesmoAppInstalled = appInstalledOrNot(FIDESMO_APP);
+
         // Link UI elements to listeners
         serviceDeliveryButton.setOnClickListener(new OnClickListener() {
             @Override
             public void onClick(View v) {
                 Log.i(TAG, "Pushed the Service Delivery API button");
-                // call the example Activity that uses the Service Delivery API
-                startActivity(new Intent(v.getContext(), ServiceDeliveryActivity.class));
+                if (fidesmoAppInstalled) {
+                    // call the example Activity that uses the Service Delivery API
+                    startActivity(new Intent(v.getContext(), ServiceDeliveryActivity.class));
+                } else {
+                    notifyMustInstall();
+                }
             }
         });
 
@@ -39,10 +51,34 @@ public class MainActivity extends Activity {
             @Override
             public void onClick(View v) {
                 Log.i(TAG, "Pushed the Transceive API button");
-                // call the example Activity that uses the Transceive API
-                startActivity(new Intent(v.getContext(), TransceiveActivity.class));
+                if (fidesmoAppInstalled) {
+                    // call the example Activity that uses the Transceive API
+                    startActivity(new Intent(v.getContext(), TransceiveActivity.class));
+                } else {
+                    notifyMustInstall();
+                }
             }
         });
-
     }
+
+    // Use the package manager to detect if the Fidesmo App is installed on the phone
+    private boolean appInstalledOrNot(String uri) {
+        PackageManager pm = getPackageManager();
+        boolean app_installed = false;
+        try {
+            pm.getPackageInfo(uri, PackageManager.GET_ACTIVITIES);
+            app_installed = true;
+        }
+        catch (PackageManager.NameNotFoundException e) {
+            Log.i(TAG, "Fidesmo App not installed in phone");
+            app_installed = false;
+        }
+        return app_installed;
+    }
+
+    // Show a Toast message to the user informing that Fidesmo App must be installed
+    private void notifyMustInstall() {
+        Toast.makeText(getApplicationContext(), R.string.install_app_message, Toast.LENGTH_LONG).show();
+    }
+
 }

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -7,6 +7,7 @@
     <string name="introduction">Sample client app showing how to use the Fidesmo App. Choose the API to use:</string>
     <string name="transceive_button">Transceive API</string>
     <string name="service_delivery_button">Service Delivery API</string>
+    <string name="install_app_message">Fidesmo App is not installed in this phone. Please install it from Google Play!</string>
    
     
     <!-- strings for Transceive API -->


### PR DESCRIPTION
When calling an explicit Intent and the called app is not installed, the calling app crashes in a not too elegant way. Try to fix it.

This is a low-priority issue.
